### PR TITLE
Enable universal response logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,9 @@ Setting the environment variable `DEBUG=true` prints full API request and respon
 DEBUG=true codex
 ```
 
+All API responses are also written to `responses.log` in the current
+directory so you can audit model interactions regardless of the provider.
+
 ---
 
 ## Recipes

--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -805,17 +805,12 @@ export class AgentLoop {
               .filter(Boolean)
               .join("\n");
 
-            const responseCall =
-              !this.config.provider ||
-              this.config.provider?.toLowerCase() === "openai"
-                ? (params: ResponseCreateParams) =>
-                    this.oai.responses.create(params)
-                : (params: ResponseCreateParams) =>
-                    responsesCreateViaChatCompletions(
-                      this.oai,
-                      params as ResponseCreateParams & { stream: true },
-                      rateLimiter,
-                    );
+            const responseCall = (params: ResponseCreateParams) =>
+              responsesCreateViaChatCompletions(
+                this.oai,
+                params as ResponseCreateParams & { stream: true },
+                rateLimiter,
+              );
             log(
               `instructions (length ${mergedInstructions.length}): ${mergedInstructions}`,
             );
@@ -1194,17 +1189,12 @@ export class AgentLoop {
                 .filter(Boolean)
                 .join("\n");
 
-              const responseCall =
-                !this.config.provider ||
-                this.config.provider?.toLowerCase() === "openai"
-                  ? (params: ResponseCreateParams) =>
-                      this.oai.responses.create(params)
-                  : (params: ResponseCreateParams) =>
-                      responsesCreateViaChatCompletions(
-                        this.oai,
-                        params as ResponseCreateParams & { stream: true },
-                        rateLimiter,
-                      );
+              const responseCall = (params: ResponseCreateParams) =>
+                responsesCreateViaChatCompletions(
+                  this.oai,
+                  params as ResponseCreateParams & { stream: true },
+                  rateLimiter,
+                );
 
               log(
                 "agentLoop.run(): responseCall(1): turnInput: " +


### PR DESCRIPTION
## Summary
- always use the `responsesCreateViaChatCompletions` pathway
- note that `responses.log` captures API output

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68515daff9c0832a812cdc10c157c8a6