### PR TITLE
Add dummy black box sandbox

### DIFF
--- a/codex-rs/cli/src/lib.rs
+++ b/codex-rs/cli/src/lib.rs
@@ -40,3 +40,13 @@ pub struct LandlockCommand {
     #[arg(trailing_var_arg = true)]
     pub command: Vec<String>,
 }
+
+#[derive(Debug, Parser)]
+pub struct BlackBoxCommand {
+    #[clap(skip)]
+    pub config_overrides: CliConfigOverrides,
+
+    /// Full command args accepted without execution.
+    #[arg(trailing_var_arg = true)]
+    pub command: Vec<String>,
+}

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use codex_cli::LandlockCommand;
 use codex_cli::SeatbeltCommand;
+use codex_cli::BlackBoxCommand;
 use codex_cli::login::run_login_with_chatgpt;
 use codex_cli::proto;
 use codex_common::CliConfigOverrides;
@@ -64,6 +65,9 @@ enum DebugCommand {
 
     /// Run a command under Landlock+seccomp (Linux only).
     Landlock(LandlockCommand),
+
+    /// Approve a command without executing it.
+    BlackBox(BlackBoxCommand),
 }
 
 #[derive(Debug, Parser)]
@@ -119,6 +123,10 @@ async fn cli_main(codex_linux_sandbox_exe: Option<PathBuf>) -> anyhow::Result<()
                     codex_linux_sandbox_exe,
                 )
                 .await?;
+            }
+            DebugCommand::BlackBox(mut black_cli) => {
+                prepend_config_flags(&mut black_cli.config_overrides, cli.config_overrides);
+                codex_cli::debug_sandbox::run_command_black_box(black_cli).await?;
             }
         },
     }

--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -55,6 +55,11 @@ const MACOS_PATH_TO_SEATBELT_EXECUTABLE: &str = "/usr/bin/sandbox-exec";
 /// attributes, so this may change in the future.
 pub const CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR: &str = "CODEX_SANDBOX_NETWORK_DISABLED";
 
+/// When this variable is set to a non-empty value, all sandbox implementations
+/// are replaced with a dummy "black box" sandbox that merely reports success
+/// without executing any commands.
+pub const CODEX_DUMMY_SANDBOX_ENV_VAR: &str = "CODEX_DUMMY_SANDBOX";
+
 #[derive(Debug, Clone)]
 pub struct ExecParams {
     pub command: Vec<String>,
@@ -66,6 +71,9 @@ pub struct ExecParams {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum SandboxType {
     None,
+
+    /// Dummy sandbox that pretends the command executed successfully.
+    BlackBox,
 
     /// Only available on macOS.
     MacosSeatbelt,
@@ -83,8 +91,20 @@ pub async fn process_exec_tool_call(
 ) -> Result<ExecToolCallOutput> {
     let start = Instant::now();
 
+    let mut sandbox_type = sandbox_type;
+    if std::env::var(CODEX_DUMMY_SANDBOX_ENV_VAR).is_ok() {
+        sandbox_type = SandboxType::BlackBox;
+    }
+
     let raw_output_result = match sandbox_type {
         SandboxType::None => exec(params, sandbox_policy, ctrl_c).await,
+        SandboxType::BlackBox => {
+            Ok(RawExecToolCallOutput {
+                exit_status: synthetic_exit_status(0),
+                stdout: Vec::new(),
+                stderr: Vec::new(),
+            })
+        }
         SandboxType::MacosSeatbelt => {
             let ExecParams {
                 command,
@@ -147,7 +167,9 @@ pub async fn process_exec_tool_call(
             // a command, and it returns anything other than success, we assume that it may have
             // been a sandboxing error and allow the user to retry. (The user of course may choose
             // not to retry, or in a non-interactive mode, would automatically reject the approval.)
-            if exit_code != 0 && sandbox_type != SandboxType::None {
+            if exit_code != 0 &&
+                !(matches!(sandbox_type, SandboxType::None | SandboxType::BlackBox))
+            {
                 return Err(CodexErr::Sandbox(SandboxErr::Denied(
                     exit_code, stdout, stderr,
                 )));

--- a/codex-rs/core/src/safety.rs
+++ b/codex-rs/core/src/safety.rs
@@ -104,6 +104,9 @@ pub fn assess_command_safety(
 }
 
 pub fn get_platform_sandbox() -> Option<SandboxType> {
+    if std::env::var(crate::exec::CODEX_DUMMY_SANDBOX_ENV_VAR).is_ok() {
+        return Some(SandboxType::BlackBox);
+    }
     if cfg!(target_os = "macos") {
         Some(SandboxType::MacosSeatbelt)
     } else if cfg!(target_os = "linux") {


### PR DESCRIPTION
## Summary
- add `CODEX_DUMMY_SANDBOX_ENV_VAR` for enabling a black box sandbox
- implement `SandboxType::BlackBox` that simply reports success
- allow selecting the black box via `--debug` subcommand
- expose a `BlackBoxCommand` and handler

## Testing
- `cargo test --quiet` *(fails: Sandbox Denied)*

------
https://chatgpt.com/codex/tasks/task_e_685108879254832aa0535e891b70d545