### PR TITLE
Add Windows sandbox skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,10 @@ The hardening mechanism Codex uses depends on your OS:
   OpenAI API. This gives you deterministic, reproducible runs without needing
   root on the host. You can use the [`run_in_container.sh`](./codex-cli/scripts/run_in_container.sh) script to set up the sandbox.
 
+- **Windows (experimental)** - a future update may include a sandbox that runs commands under a
+  restricted Windows user account. The current codebase includes a non-functional skeleton for this
+  approach.
+
 ---
 
 ## System requirements

--- a/codex-rs/cli/src/debug_sandbox.rs
+++ b/codex-rs/cli/src/debug_sandbox.rs
@@ -7,6 +7,7 @@ use codex_core::config::ConfigOverrides;
 use codex_core::exec::StdioPolicy;
 use codex_core::exec::spawn_command_under_linux_sandbox;
 use codex_core::exec::spawn_command_under_seatbelt;
+use codex_core::exec::spawn_command_under_windows_user;
 use codex_core::exec_env::create_env;
 use codex_core::protocol::SandboxPolicy;
 
@@ -59,6 +60,7 @@ pub async fn run_command_under_landlock(
 enum SandboxType {
     Seatbelt,
     Landlock,
+    WindowsUser,
 }
 
 async fn run_command_under_sandbox(
@@ -96,6 +98,16 @@ async fn run_command_under_sandbox(
                 .expect("codex-linux-sandbox executable not found");
             spawn_command_under_linux_sandbox(
                 codex_linux_sandbox_exe,
+                command,
+                &config.sandbox_policy,
+                cwd,
+                stdio_policy,
+                env,
+            )
+            .await?
+        }
+        SandboxType::WindowsUser => {
+            spawn_command_under_windows_user(
                 command,
                 &config.sandbox_policy,
                 cwd,


### PR DESCRIPTION
## Summary
- add placeholder `WindowsUser` sandbox type and stub handler
- expose new sandbox option via CLI debug command
- mention experimental Windows sandbox in documentation

## Testing
- `cargo check --workspace --quiet`
- `cargo test --no-run --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6851967d5784832a91a3bea581cef680