### PR TITLE
Expose codex-core modules

### DIFF
--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -5,7 +5,28 @@ pub mod config;
 pub mod protocol;
 // Add other module declarations if needed, e.g.:
 // pub mod codex;
-// pub mod another_module;/// global feature flags and defaults
+// pub mod another_module;
+
+/// High level Codex interface
+pub mod codex;
+
+/// Command execution utilities
+pub mod exec;
+pub mod client;
+pub mod client_common;
+pub mod conversation_history;
+pub mod mcp_connection_manager;
+pub mod mcp_tool_call;
+pub mod models;
+pub mod chat_completions;
+pub mod openai_tools;
+pub mod is_safe_command;
+pub mod project_doc;
+pub mod rollout;
+pub mod safety;
+pub mod user_notification;
+pub mod util;
+/// global feature flags and defaults
 pub mod flags;
 
 /// profiles of per-organization/OpenAI config
@@ -13,3 +34,16 @@ pub mod config_profile;
 
 /// per-model/provider metadata
 pub mod model_provider_info;
+
+/// error types
+pub mod error;
+
+/// message history persistence
+pub mod message_history;
+
+/// OpenAI API key utilities
+pub mod openai_api_key;
+
+pub use model_provider_info::WireApi;
+pub use codex::Codex;
+pub use model_provider_info::ModelProviderInfo;


### PR DESCRIPTION
## Summary
- make codex-core public modules consistent
- re-export `ModelProviderInfo`

## Testing
- `cargo check -p codex-core`
- `cargo test -p codex-core` *(fails: could not compile `codex-core` (test `exec_api_test`))*

------
https://chatgpt.com/codex/tasks/task_e_68521cb89238832a9fb57920aca249d1