### PR TITLE
Fix crate path imports and cleanup

### DIFF
--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -738,7 +738,7 @@ disable_response_storage = true
             name: "OpenAI using Chat Completions".to_string(),
             base_url: "https://api.openai.com/v1".to_string(),
             env_key: Some("OPENAI_API_KEY".to_string()),
-            wire_api: core::WireApi::Chat,
+            wire_api: crate::WireApi::Chat,
             env_key_instructions: None,
         };
         let model_provider_map = {

--- a/codex-rs/core/src/model_provider_info.rs
+++ b/codex-rs/core/src/model_provider_info.rs
@@ -10,8 +10,8 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::env::VarError;
 
-use core::error::EnvVarError;
-use core::openai_api_key::get_openai_api_key;
+use crate::error::EnvVarError;
+use crate::openai_api_key::get_openai_api_key;
 
 /// Wire protocol that the provider speaks. Most third-party services only
 /// implement the classic OpenAI Chat Completions JSON schema, whereas OpenAI

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -17,7 +17,7 @@ use crate::config_types::ReasoningSummary as ReasoningSummaryConfig;
 use codex_execpolicy::threat_state::{ThreatMatrix, ThreatLevel};
 
 use codex_execpolicy::policy_watcher::PolicyWatcher;
-use core::message_history::HistoryEntry;
+use crate::message_history::HistoryEntry;
 use crate::model_provider_info::ModelProviderInfo;
 
 /// Submission Queue Entry - requests from user

--- a/codex-rs/core/tests/exec_api_test.rs
+++ b/codex-rs/core/tests/exec_api_test.rs
@@ -1,19 +1,15 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::Arc;
-use tokio::sync::Notify;
-use super::protocol::SandboxPolicy;
-use super::exec_env::{spawn_command_under_api, StdioPolicy};
+use codex_core::protocol::SandboxPolicy;
+use codex_core::exec::{spawn_command_under_api, StdioPolicy};
 
 #[tokio::test]
 async fn test_spawn_command_under_api() {
     let command = vec!["echo".to_string(), "Hello, World!".to_string()];
-    let sandbox_policy = SandboxPolicy::default(); // Assuming a default implementation exists
+    let sandbox_policy = SandboxPolicy::new_full_auto_policy();
     let cwd = PathBuf::from(".");
     let stdio_policy = StdioPolicy::RedirectForShellTool;
     let env = HashMap::new();
-
-    let ctrl_c = Arc::new(Notify::new());
 
     match spawn_command_under_api(command, &sandbox_policy, cwd, stdio_policy, env).await {
         Ok(child) => {


### PR DESCRIPTION
## Summary
- fix wrong `core::` imports
- patch exec API test to remove unused imports
- ensure config test uses `WireApi` from crate

## Testing
- `cargo test -p codex-core`

------
https://chatgpt.com/codex/tasks/task_e_685220a3c000832aafd730cc6de03ee2