### PR TITLE
Fix missing exports for codex_core

### DIFF
--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -44,6 +44,10 @@ pub mod message_history;
 /// OpenAI API key utilities
 pub mod openai_api_key;
 
+pub mod codex_wrapper;
+
+pub use client_common::model_supports_reasoning_summaries;
+
 pub use model_provider_info::WireApi;
 pub use codex::Codex;
 pub use model_provider_info::ModelProviderInfo;


### PR DESCRIPTION
## Summary
- expose `codex_wrapper` module from `codex_core`
- re-export `model_supports_reasoning_summaries`

## Testing
- `cargo test -p codex-core --no-run`
- `cargo check -p codex-exec -p codex-mcp-server -p codex-tui`
- `cargo test -p codex-exec --no-run`
- `cargo test -p codex-mcp-server --no-run`
- `cargo test -p codex-tui --no-run`


------
https://chatgpt.com/codex/tasks/task_e_685225439d20832a856c73186a46a7d2