### PR TITLE
Fix match coverage for debug sandbox

### DIFF
--- a/codex-rs/cli/src/debug_sandbox.rs
+++ b/codex-rs/cli/src/debug_sandbox.rs
@@ -149,6 +149,7 @@ async fn run_command_under_sandbox(
             )
             .await?
         }
+        SandboxType::BlackBox => unreachable!("handled above"),
     };
     let status = child.wait().await?;
 


### PR DESCRIPTION
## Summary
- handle `SandboxType::BlackBox` in `debug_sandbox` to satisfy compiler

## Testing
- `cargo test -p codex-cli`
- `cargo test -p codex-core -- --test-threads=1 --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_685230f8887c832ab2de30eea2a09d00