### PR TITLE
Use risk CSV for policy reloads

### DIFF
--- a/codex-rs/execpolicy/src/lib.rs
+++ b/codex-rs/execpolicy/src/lib.rs
@@ -18,6 +18,10 @@ mod program;
 mod sed_command;
 mod valid_exec;
 
+use lazy_static::lazy_static;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
 pub use arg_matcher::ArgMatcher;
 pub use arg_resolver::PositionalArg;
 pub use arg_type::ArgType;
@@ -43,7 +47,27 @@ pub use valid_exec::ValidExec;
 
 const DEFAULT_POLICY: &str = include_str!("default.policy");
 
+lazy_static! {
+    static ref DEFAULT_WATCHER: Mutex<Option<PolicyWatcher>> = Mutex::new(None);
+}
+
 pub fn get_default_policy() -> starlark::Result<Policy> {
+    {
+        let mut guard = DEFAULT_WATCHER.lock().expect("lock poisoned");
+        if let Some(watcher) = guard.as_ref() {
+            let _ = watcher.reload();
+            return Ok(watcher.policy());
+        }
+
+        let path = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/src/default.policy"));
+        if let Ok(watcher) = PolicyWatcher::new(path) {
+            let _ = watcher.reload();
+            let policy = watcher.policy();
+            *guard = Some(watcher);
+            return Ok(policy);
+        }
+    }
+
     let parser = PolicyParser::new("#default", DEFAULT_POLICY);
     parser.parse()
 }


### PR DESCRIPTION
## Summary
- update policy watcher to read `risk_csv.csv`
- derive risk scores from the CSV columns
- watch the default policy dynamically via a cached `PolicyWatcher`
- bump risk reload threshold

## Testing
- `cargo test -p codex-execpolicy`

------
https://chatgpt.com/codex/tasks/task_e_6852453906bc832aa4933966449bbd44