### PR TITLE
Improve threat scoring flow

### DIFF
--- a/codex-rs/execpolicy/src/policy_watcher.rs
+++ b/codex-rs/execpolicy/src/policy_watcher.rs
@@ -5,34 +5,49 @@ use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 
 use anyhow::Context;
 use crate::{Policy, PolicyParser};
-use crate::threat_state::{ThreatMatrix, ThreatAssessment};
+use crate::threat_state::{
+    ThreatMatrix,
+    ThreatAssessment,
+    ThreatDeliverable,
+    RiskVector,
+    ThreatLevel,
+    DEFAULT_CATEGORY_WEIGHTS,
+    load_risk_tree,
+    generate_deliverables_with_weights,
+    load_risk_matrix,
+    risk_vector_score,
+    DEFAULT_RISK_SCORE,
+};
 
 /// Path to the CSV database containing risk assessment scores.
 ///
-/// This is a stub implementation. In the future this should be replaced with
-/// a real data source and risk evaluation logic.
-const RISK_DB_PATH: &str = "risk_db.csv";
+/// The risk matrix is derived from this CSV at runtime.
+const RISK_CSV_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/src/risk_csv.csv");
 
 /// Threshold above which policy reloads should be rejected.
 const RISK_THRESHOLD: f64 = 0.5;
 
-/// Load the risk score from `RISK_DB_PATH`.
-///
-/// This stub reads the first numeric value from the CSV and returns it. If the
-/// file does not exist or the contents are malformed, `0.0` is returned so that
-/// existing behaviour is preserved.
+
+/// Load the overall risk score from `RISK_CSV_PATH` by averaging all metrics.
+/// If the CSV cannot be read, [`DEFAULT_RISK_SCORE`] is returned so that existing
+/// behaviour is preserved.
 fn current_risk_score() -> f64 {
-    let Ok(content) = std::fs::read_to_string(RISK_DB_PATH) else {
-        return 0.0;
+    let Ok(tree) = load_risk_tree(std::path::Path::new(RISK_CSV_PATH)) else {
+        return DEFAULT_RISK_SCORE;
     };
-    for line in content.lines().skip(1) {
-        if let Some(field) = line.split(',').next() {
-            if let Ok(score) = field.trim().parse::<f64>() {
-                return score;
+    let mut sum = 0.0;
+    let mut count = 0;
+    for env in tree.values() {
+        for cmd in env.values() {
+            for vec in cmd.values() {
+                for v in vec {
+                    sum += *v;
+                    count += 1;
+                }
             }
         }
     }
-    0.0
+    if count == 0 { DEFAULT_RISK_SCORE } else { sum / count as f64 }
 }
 
 /// Watches a policy file and reloads it when modified.
@@ -101,11 +116,11 @@ impl PolicyWatcher {
 
     /// Registers a new tool and its risk score in the risk database.
     ///
-    /// This appends the tool and score to the `RISK_DB_PATH` CSV file.
+    /// This appends the tool and score to the `RISK_CSV_PATH` CSV file.
     pub fn register_tool(&self, tool_name: &str, risk_score: f64) -> anyhow::Result<()> {
-        let mut content = std::fs::read_to_string(RISK_DB_PATH).unwrap_or_default();
+        let mut content = std::fs::read_to_string(RISK_CSV_PATH).unwrap_or_default();
         content.push_str(&format!("\n{},{}", tool_name, risk_score));
-        std::fs::write(RISK_DB_PATH, content).context("writing to risk database")?;
+        std::fs::write(RISK_CSV_PATH, content).context("writing to risk database")?;
         Ok(())
     }
 
@@ -121,28 +136,23 @@ impl PolicyWatcher {
     }
 
     /// Decomposes a list of command strings into their base flags and compiles a batch of CSV values.
-    pub fn compile_csv_batch(&self, commands: Vec<String>) -> anyhow::Result<Vec<(String, f64)>> {
+    pub fn compile_csv_batch(&self, commands: Vec<String>, env: Option<&str>) -> anyhow::Result<Vec<(String, RiskVector)>> {
+        let tree = load_risk_tree(std::path::Path::new(RISK_CSV_PATH))?;
         let mut results = Vec::new();
-        let Ok(content) = std::fs::read_to_string(RISK_DB_PATH) else {
-            return Ok(results);
-        };
-
-        let csv_data: Vec<(String, f64)> = content
-            .lines()
-            .skip(1) // Skip header
-            .filter_map(|line| {
-                let mut fields = line.split(',');
-                let tool_name = fields.next()?.trim().to_string();
-                let risk_score = fields.next()?.trim().parse::<f64>().ok()?;
-                Some((tool_name, risk_score))
-            })
-            .collect();
+        let environment = env.map(|e| e.to_lowercase()).unwrap_or_else(|| std::env::consts::OS.to_lowercase());
 
         for command in commands {
-            let flags: Vec<String> = command.split_whitespace().map(|s| s.to_string()).collect();
-            for flag in flags {
-                if let Some((tool_name, risk_score)) = csv_data.iter().find(|(name, _)| name == &flag) {
-                    results.push((tool_name.clone(), *risk_score));
+            let mut parts = command.split_whitespace();
+            if let Some(cmd) = parts.next() {
+                let flags: Vec<String> = parts.map(|s| s.to_string()).collect();
+                if let Some(env_map) = tree.get(&environment) {
+                    if let Some(cmd_map) = env_map.get(cmd) {
+                        for flag in &flags {
+                            if let Some(vec) = cmd_map.get(flag) {
+                                results.push((flag.clone(), vec.clone()));
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -150,25 +160,45 @@ impl PolicyWatcher {
         Ok(results)
     }
 
-    /// Stub for modulating results based on history and combined patterns.
-    pub fn modulate_results(&self, batch: Vec<(String, f64)>) -> Vec<(String, f64)> {
-        // Placeholder for future implementation
+    /// Combine category scores from threat state into a single risk score.
+    pub fn modulate_results(&self, batch: Vec<(String, RiskVector)>) -> Vec<(String, f64)> {
         batch
+            .into_iter()
+            .map(|(flag, vec)| {
+                let score = risk_vector_score(&vec);
+                (flag, score)
+            })
+            .collect()
     }
 
     /// Processes the dimensionality of a ThreatMatrix based on the CSV data and commands.
     pub fn process_threat_matrix(&self, commands: Vec<String>) -> ThreatMatrix {
-        let mut matrix = ThreatMatrix::new(100, 0.1); // Example parameters: max_size=100, decay_factor=0.1
+        let mut matrix = match load_risk_matrix(std::path::Path::new(RISK_CSV_PATH)) {
+            Ok(m) => m,
+            Err(_) => ThreatMatrix::new(0, 0.0),
+        };
 
-        if let Ok(batch) = self.compile_csv_batch(commands) {
-            for (tool_name, risk_score) in batch {
-                let assessment = ThreatAssessment::new(risk_score, risk_score * 1.2, vec![tool_name]);
+        if let Ok(batch) = self.compile_csv_batch(commands, None) {
+            let scored = self.modulate_results(batch);
+            for (tool_name, risk_score) in scored {
+                let assessment = ThreatAssessment::new(risk_score, risk_score, vec![tool_name]);
                 matrix.add_assessment(assessment);
             }
         }
 
         matrix.apply_decay();
         matrix
+    }
+
+    /// Generates threat deliverables by overlaying the current CSV with historical data.
+    pub fn threat_deliverables(&self, csv_path: &PathBuf) -> anyhow::Result<ThreatDeliverable> {
+        let tree = load_risk_tree(csv_path)?;
+        Ok(generate_deliverables_with_weights(tree, &DEFAULT_CATEGORY_WEIGHTS))
+    }
+
+    /// Evaluate a [`ThreatMatrix`] and return the overall [`ThreatLevel`].
+    pub fn evaluate_matrix(&self, matrix: &ThreatMatrix) -> ThreatLevel {
+        matrix.evaluate()
     }
 }
 

--- a/codex-rs/execpolicy/src/threat_state.rs
+++ b/codex-rs/execpolicy/src/threat_state.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::collections::{BTreeMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
@@ -130,6 +130,15 @@ impl ThreatMatrix {
         });
     }
 
+    /// Compute the average evaluated danger stored in this matrix.
+    pub fn average_danger(&self) -> f64 {
+        if self.window.is_empty() {
+            return DEFAULT_RISK_SCORE;
+        }
+        let sum: f64 = self.window.iter().map(|a| a.evaluated_danger).sum();
+        sum / self.window.len() as f64
+    }
+
     /// Prunes uninteresting items from the rolling window.
     fn prune_uninteresting(&mut self) {
         self.window.pop_front();
@@ -181,11 +190,19 @@ impl ThreatMatrix {
         (*guard).clone()
     }
 
-    /// Stub implementation for `evaluate`.
-    /// Returns an n-dimensional tensor representation of the matrix.
+    /// Evaluate the current matrix and return the [`ThreatLevel`].
     pub fn evaluate(&self) -> ThreatLevel {
-        // Placeholder logic: return a default ThreatLevel.
-        ThreatLevel::Low
+        let avg = self.average_danger();
+        if avg == DEFAULT_RISK_SCORE {
+            return ThreatLevel::Low;
+        }
+        if avg > THREAT_HIGH_THRESHOLD {
+            ThreatLevel::High
+        } else if avg > THREAT_MEDIUM_THRESHOLD {
+            ThreatLevel::Medium
+        } else {
+            ThreatLevel::Low
+        }
     }
 }
 
@@ -198,4 +215,228 @@ impl ThreatAssessment {
             flags,
         }
     }
+}
+
+/// Vector of threat metrics per flag.
+pub type RiskVector = Vec<f64>;
+
+/// Tree structure mapping environment -> command -> flag -> risk vector.
+pub type RiskTree = BTreeMap<String, BTreeMap<String, BTreeMap<String, RiskVector>>>;
+
+/// Default category weights applied during projection.
+pub const DEFAULT_CATEGORY_WEIGHTS: [f64; 5] = [1.0; 5];
+
+/// Default risk score when no data is available.
+pub const DEFAULT_RISK_SCORE: f64 = 0.0;
+
+/// Threshold at which [`ThreatLevel::Medium`] is triggered.
+pub const THREAT_MEDIUM_THRESHOLD: f64 = 2.0;
+
+/// Threshold at which [`ThreatLevel::High`] is triggered.
+pub const THREAT_HIGH_THRESHOLD: f64 = 4.0;
+
+/// Sum a weighted [`RiskVector`] into a single risk score.
+pub fn risk_vector_score(vec: &RiskVector) -> f64 {
+    vec.iter().sum()
+}
+
+#[derive(Clone, Debug, Default)]
+/// Historical tree storage with a moving window.
+pub struct RiskHistory {
+    window: VecDeque<RiskTree>,
+    decay_factor: f64,
+    max_size: usize,
+}
+
+lazy_static! {
+    /// Global historical tree for threat evaluations.
+    static ref HISTORICAL_TREE: Mutex<RiskHistory> = Mutex::new(RiskHistory::new(100, 0.05));
+}
+
+impl RiskHistory {
+    pub fn new(max_size: usize, decay_factor: f64) -> Self {
+        Self { window: VecDeque::new(), decay_factor, max_size }
+    }
+
+    /// Add a new risk tree to the historical window.
+    pub fn add_tree(&mut self, tree: RiskTree) {
+        if self.window.len() >= self.max_size {
+            self.prune_uninteresting();
+        }
+        self.window.push_back(tree);
+    }
+
+    /// Simple decay-based pruning of the oldest element.
+    fn prune_uninteresting(&mut self) {
+        if self.window.is_empty() {
+            return;
+        }
+        let (idx, _) = self
+            .window
+            .iter()
+            .enumerate()
+            .map(|(i, tree)| {
+                let mut sum = 0.0;
+                let mut count = 0;
+                for env in tree.values() {
+                    for cmd in env.values() {
+                        for vec in cmd.values() {
+                            for v in vec {
+                                sum += *v;
+                                count += 1;
+                            }
+                        }
+                    }
+                }
+                let avg = if count == 0 { 0.0 } else { sum / count as f64 };
+                (i, avg)
+            })
+            .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+            .unwrap();
+        self.window.remove(idx);
+    }
+
+    /// Blend historical trees with the current tree using averaging.
+    pub fn blend_with_history(&self, current: &RiskTree) -> RiskTree {
+        let mut sums: RiskTree = BTreeMap::new();
+        let mut counts: BTreeMap<(String, String, String), usize> = BTreeMap::new();
+
+        let iter = self.window.iter().chain(std::iter::once(current));
+
+        for tree in iter {
+            for (env, cmd_map) in tree {
+                for (cmd, flag_map) in cmd_map {
+                    for (flag, vec) in flag_map {
+                        let entry = sums
+                            .entry(env.clone())
+                            .or_default()
+                            .entry(cmd.clone())
+                            .or_default()
+                            .entry(flag.clone())
+                            .or_insert_with(|| vec![0.0; vec.len()]);
+                        for (i, v) in vec.iter().enumerate() {
+                            if i < entry.len() {
+                                entry[i] += v;
+                            }
+                        }
+                        *counts.entry((env.clone(), cmd.clone(), flag.clone())).or_insert(0) += 1;
+                    }
+                }
+            }
+        }
+
+        // Compute averages
+        for ((env, cmd, flag), count) in counts {
+            if let Some(env_map) = sums.get_mut(&env) {
+                if let Some(cmd_map) = env_map.get_mut(&cmd) {
+                    if let Some(vec) = cmd_map.get_mut(&flag) {
+                        for v in vec.iter_mut() {
+                            *v /= count as f64;
+                        }
+                    }
+                }
+            }
+        }
+        sums
+    }
+
+    /// Access historical window clone.
+    pub fn history(&self) -> Vec<RiskTree> {
+        self.window.iter().cloned().collect()
+    }
+}
+
+/// Apply categorical weights to all risk vectors in a tree.
+pub fn apply_weights(tree: &RiskTree, weights: &[f64]) -> RiskTree {
+    let mut weighted: RiskTree = BTreeMap::new();
+    for (env, cmd_map) in tree {
+        for (cmd, flag_map) in cmd_map {
+            for (flag, vec) in flag_map {
+                let mut new_vec = Vec::with_capacity(vec.len());
+                for (i, v) in vec.iter().enumerate() {
+                    let w = weights.get(i).copied().unwrap_or(1.0);
+                    new_vec.push(v * w);
+                }
+                weighted
+                    .entry(env.clone())
+                    .or_default()
+                    .entry(cmd.clone())
+                    .or_default()
+                    .insert(flag.clone(), new_vec);
+            }
+        }
+    }
+    weighted
+}
+
+/// Load a risk tree from a CSV file with the format produced by `risk_csv.csv`.
+pub fn load_risk_tree(path: &Path) -> anyhow::Result<RiskTree> {
+    let content = std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let mut tree: RiskTree = BTreeMap::new();
+
+    for line in content.lines().skip(1) {
+        let fields: Vec<&str> = line.split(',').collect();
+        if fields.len() < 4 {
+            continue;
+        }
+        let env = fields[0].trim().to_string();
+        let cmd = fields[1].trim().to_string();
+        let flag = fields[2].trim().to_string();
+        let mut vec = Vec::new();
+        for f in &fields[3..] {
+            if let Ok(num) = f.trim().parse::<f64>() {
+                vec.push(num);
+            }
+        }
+        tree
+            .entry(env)
+            .or_default()
+            .entry(cmd)
+            .or_default()
+            .insert(flag, vec);
+    }
+
+    Ok(tree)
+}
+
+#[derive(Clone, Debug)]
+pub struct ThreatDeliverable {
+    pub historical: Vec<RiskTree>,
+    pub projected: RiskTree,
+    pub final_tree: RiskTree,
+}
+
+/// Generate deliverables based on the current tree and historical data.
+pub fn generate_deliverables_with_weights(current: RiskTree, weights: &[f64]) -> ThreatDeliverable {
+    let mut history = HISTORICAL_TREE.lock().expect("Failed to lock historical tree");
+    history.add_tree(current.clone());
+    let projected = history.blend_with_history(&current);
+    let final_tree = apply_weights(&projected, weights);
+    ThreatDeliverable {
+        historical: history.history(),
+        projected,
+        final_tree,
+    }
+}
+
+/// Convenience wrapper using [`DEFAULT_CATEGORY_WEIGHTS`].
+pub fn generate_deliverables(current: RiskTree) -> ThreatDeliverable {
+    generate_deliverables_with_weights(current, &DEFAULT_CATEGORY_WEIGHTS)
+}
+
+/// Convert a `RiskTree` loaded from the CSV into a `ThreatMatrix`.
+pub fn load_risk_matrix(path: &Path) -> anyhow::Result<ThreatMatrix> {
+    let tree = load_risk_tree(path)?;
+    let mut matrix = ThreatMatrix::new(100, 0.05);
+
+    for env in tree.values() {
+        for cmd in env.values() {
+            for (flag, vec) in cmd {
+                let score = if vec.is_empty() { DEFAULT_RISK_SCORE } else { vec.iter().sum::<f64>() / vec.len() as f64 };
+                matrix.add_assessment(ThreatAssessment::new(score, score, vec![flag.clone()]));
+            }
+        }
+    }
+
+    Ok(matrix)
 }


### PR DESCRIPTION
## Summary
- return default risk score as constant when risk CSV can't be read
- prevent double weighting by moving scoring logic into `threat_state`
- evaluate threat levels inside `ThreatMatrix`
- provide `risk_vector_score` helper and new threat-level constants

## Testing
- `cargo check -p codex-execpolicy`


------
https://chatgpt.com/codex/tasks/task_e_68531786741c832a8dbdf4c61df925af