### PR TITLE
Fix Clap parsers in codex-common

### DIFF
--- a/codex-rs/common/src/approval_mode_cli_arg.rs
+++ b/codex-rs/common/src/approval_mode_cli_arg.rs
@@ -78,16 +78,18 @@ impl std::str::FromStr for SandboxPermissionOption {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(SandboxPermissionOption {
-            permissions: Some(vec![parse_sandbox_permission(s)?]),
+            permissions: Some(vec![parse_sandbox_permission(s).map_err(|e| e.to_string())?]),
         })
     }
 }
 
 impl ValueParserFactory for SandboxPermissionOption {
-    fn value_parser() -> ValueParser {
-        ValueParser::new(|s: &str| {
+    type Parser = ValueParser;
+
+    fn value_parser() -> Self::Parser {
+        ValueParser::new(|s: &str| -> Result<SandboxPermissionOption, String> {
             Ok(SandboxPermissionOption {
-                permissions: Some(vec![parse_sandbox_permission(s)?]),
+                permissions: Some(vec![parse_sandbox_permission(s).map_err(|e| e.to_string())?]),
             })
         })
     }

--- a/codex-rs/common/src/config_override.rs
+++ b/codex-rs/common/src/config_override.rs
@@ -149,8 +149,10 @@ impl std::str::FromStr for CliConfigOverrides {
 }
 
 impl ValueParserFactory for CliConfigOverrides {
-    fn value_parser() -> ValueParser {
-        ValueParser::new(|s: &str| {
+    type Parser = ValueParser;
+
+    fn value_parser() -> Self::Parser {
+        ValueParser::new(|s: &str| -> Result<CliConfigOverrides, String> {
             Ok(CliConfigOverrides {
                 raw_overrides: vec![s.to_string()],
             })


### PR DESCRIPTION
## Summary
- convert parse errors to strings
- implement `Parser` associated type for `ValueParserFactory`
- use explicit Result types for Clap builders

## Testing
- `cargo test -p codex-common --lib --features cli`


------
https://chatgpt.com/codex/tasks/task_e_6853bf20c948832aa6f98924383b1527