### PR TITLE
Add default command translations

### DIFF
--- a/codex-rs/translation/src/command_translation.rs
+++ b/codex-rs/translation/src/command_translation.rs
@@ -16,10 +16,104 @@ pub struct CommandTranslation {
 
 impl CommandTranslator {
     pub fn new() -> Self {
-        Self {
+        let mut translator = Self {
             translations: HashMap::new(),
             max_warnings: MAX_TRANSLATION_WARNINGS,
-        }
+        };
+        translator.insert_default_map();
+        translator
+    }
+
+    fn insert_default_map(&mut self) {
+        let mut mappings = HashMap::new();
+        mappings.insert("linux".to_string(), "ls".to_string());
+        mappings.insert("macos".to_string(), "ls".to_string());
+        mappings.insert("windows".to_string(), "dir".to_string());
+        self.add_translation("ls", mappings);
+
+        let mut mappings = HashMap::new();
+        mappings.insert("linux".to_string(), "cat".to_string());
+        mappings.insert("macos".to_string(), "cat".to_string());
+        mappings.insert("windows".to_string(), "type".to_string());
+        self.add_translation("cat", mappings);
+
+        let mut mappings = HashMap::new();
+        mappings.insert("linux".to_string(), "cp".to_string());
+        mappings.insert("macos".to_string(), "cp".to_string());
+        mappings.insert("windows".to_string(), "copy".to_string());
+        self.add_translation("cp", mappings);
+
+        let mut mappings = HashMap::new();
+        mappings.insert("linux".to_string(), "mv".to_string());
+        mappings.insert("macos".to_string(), "mv".to_string());
+        mappings.insert("windows".to_string(), "move".to_string());
+        self.add_translation("mv", mappings);
+
+        let mut mappings = HashMap::new();
+        mappings.insert("linux".to_string(), "rm".to_string());
+        mappings.insert("macos".to_string(), "rm".to_string());
+        mappings.insert("windows".to_string(), "del".to_string());
+        self.add_translation("rm", mappings);
+
+        let mut mappings = HashMap::new();
+        mappings.insert("linux".to_string(), "pwd".to_string());
+        mappings.insert("macos".to_string(), "pwd".to_string());
+        mappings.insert("windows".to_string(), "cd".to_string());
+        self.add_translation("pwd", mappings);
+
+        let mut mappings = HashMap::new();
+        mappings.insert("linux".to_string(), "which".to_string());
+        mappings.insert("macos".to_string(), "which".to_string());
+        mappings.insert("windows".to_string(), "where".to_string());
+        self.add_translation("which", mappings);
+
+        let mut mappings = HashMap::new();
+        mappings.insert("linux".to_string(), "ps".to_string());
+        mappings.insert("macos".to_string(), "ps".to_string());
+        mappings.insert("windows".to_string(), "tasklist".to_string());
+        self.add_translation("ps", mappings);
+
+        let mut mappings = HashMap::new();
+        mappings.insert("linux".to_string(), "kill".to_string());
+        mappings.insert("macos".to_string(), "kill".to_string());
+        mappings.insert("windows".to_string(), "taskkill".to_string());
+        self.add_translation("kill", mappings);
+
+        let mut mappings = HashMap::new();
+        mappings.insert("linux".to_string(), "grep".to_string());
+        mappings.insert("macos".to_string(), "grep".to_string());
+        mappings.insert("windows".to_string(), "findstr".to_string());
+        self.add_translation("grep", mappings);
+
+        let mut mappings = HashMap::new();
+        mappings.insert("linux".to_string(), "clear".to_string());
+        mappings.insert("macos".to_string(), "clear".to_string());
+        mappings.insert("windows".to_string(), "cls".to_string());
+        self.add_translation("clear", mappings);
+
+        let mut mappings = HashMap::new();
+        mappings.insert("linux".to_string(), "man".to_string());
+        mappings.insert("macos".to_string(), "man".to_string());
+        mappings.insert("windows".to_string(), "help".to_string());
+        self.add_translation("man", mappings);
+
+        let mut mappings = HashMap::new();
+        mappings.insert("linux".to_string(), "mkdir".to_string());
+        mappings.insert("macos".to_string(), "mkdir".to_string());
+        mappings.insert("windows".to_string(), "mkdir".to_string());
+        self.add_translation("mkdir", mappings);
+
+        let mut mappings = HashMap::new();
+        mappings.insert("linux".to_string(), "rmdir".to_string());
+        mappings.insert("macos".to_string(), "rmdir".to_string());
+        mappings.insert("windows".to_string(), "rmdir".to_string());
+        self.add_translation("rmdir", mappings);
+
+        let mut mappings = HashMap::new();
+        mappings.insert("linux".to_string(), "echo".to_string());
+        mappings.insert("macos".to_string(), "echo".to_string());
+        mappings.insert("windows".to_string(), "echo".to_string());
+        self.add_translation("echo", mappings);
     }
 
     pub fn add_translation(


### PR DESCRIPTION
## Summary
- add built-in command translation map

## Testing
- `cargo test -p translation`

------
https://chatgpt.com/codex/tasks/task_e_6853c6582c40832abf4c9ced9662b2b8