### PR TITLE
Fix missing black box argument

### DIFF
--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -126,8 +126,11 @@ async fn cli_main(codex_linux_sandbox_exe: Option<PathBuf>) -> anyhow::Result<()
             }
             DebugCommand::BlackBox(mut black_cli) => {
                 prepend_config_flags(&mut black_cli.config_overrides, cli.config_overrides);
-                codex_cli::debug_sandbox::run_command_under_black_box(black_cli).await?;
-                //I don't know where to source the proper arguments
+                codex_cli::debug_sandbox::run_command_under_black_box(
+                    black_cli,
+                    codex_linux_sandbox_exe,
+                )
+                .await?;
             }
         },
     }


### PR DESCRIPTION
## Summary
- pass codex_linux_sandbox_exe when running a command under the black box sandbox

## Testing
- `cargo check --quiet`
- `pnpm -r test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685452d1c580832a9d0c75191f5a7c4e