### PR TITLE
Improve API sandbox handshake

### DIFF
--- a/codex-rs/cli/src/debug_sandbox.rs
+++ b/codex-rs/cli/src/debug_sandbox.rs
@@ -210,14 +210,18 @@ async fn run_command_under_sandbox(
             .await?
         }
         SandboxType::Api => {
-            spawn_command_under_api(
+            let output = spawn_command_under_api(
                 command,
                 &config.sandbox_policy,
                 cwd,
                 stdio_policy,
                 env,
+                None,
             )
-            .await?
+            .await?;
+            println!("{}", String::from_utf8_lossy(&output.stdout));
+            handle_exit_status(output.exit_status);
+            return Ok(());
         }
     };
 

--- a/codex-rs/core/tests/exec_api_test.rs
+++ b/codex-rs/core/tests/exec_api_test.rs
@@ -11,10 +11,9 @@ async fn test_spawn_command_under_api() {
     let stdio_policy = StdioPolicy::RedirectForShellTool;
     let env = HashMap::new();
 
-    match spawn_command_under_api(command, &sandbox_policy, cwd, stdio_policy, env).await {
-        Ok(child) => {
-            let output = child.wait_with_output().await.expect("Failed to wait for child process");
-            assert!(output.status.success(), "Process did not exit successfully");
+    match spawn_command_under_api(command, &sandbox_policy, cwd, stdio_policy, env, None).await {
+        Ok(output) => {
+            assert!(output.exit_status.success(), "Process did not exit successfully");
             let stdout = String::from_utf8_lossy(&output.stdout);
             assert!(stdout.contains("Hello, World!"), "Unexpected output: {}", stdout);
         }


### PR DESCRIPTION
## Summary
- refactor `spawn_command_under_api` to collect handshake in parallel with interpreter runs and prefix handshake output
- keep non-interpreter commands as no-op responses

## Testing
- `cargo test -p codex-core --test exec_api_test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_685455b54dc0832a829785167fbb5904