### PR TITLE
Improve API sandbox handshake

### DIFF
--- a/codex-rs/cli/src/debug_sandbox.rs
+++ b/codex-rs/cli/src/debug_sandbox.rs
@@ -210,14 +210,18 @@ async fn run_command_under_sandbox(
             .await?
         }
         SandboxType::Api => {
-            spawn_command_under_api(
+            let output = spawn_command_under_api(
                 command,
                 &config.sandbox_policy,
                 cwd,
                 stdio_policy,
                 env,
+                None,
             )
-            .await?
+            .await?;
+            println!("{}", String::from_utf8_lossy(&output.stdout));
+            handle_exit_status(output.exit_status);
+            return Ok(());
         }
     };
 

--- a/codex-rs/core/src/api/mod.rs
+++ b/codex-rs/core/src/api/mod.rs
@@ -1,0 +1,48 @@
+use tokio::net::{TcpListener, TcpStream};
+use tokio::time::{timeout, Duration};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::error::{CodexErr, Result};
+
+pub async fn accept_with_retries(listener: TcpListener, tries: usize, retry: Duration) -> Result<(String, Option<TcpStream>)> {
+    let mut attempts = 0usize;
+    loop {
+        if attempts >= tries {
+            return Ok(("No response on the API".to_string(), None));
+        }
+        attempts += 1;
+        match timeout(retry, listener.accept()).await {
+            Ok(Ok((mut stream, _))) => {
+                let mut compiled = Vec::new();
+                let mut buf = [0u8; 1024];
+                while let Ok(n) = stream.read(&mut buf).await {
+                    if n == 0 {
+                        break;
+                    }
+                    compiled.extend_from_slice(&buf[..n]);
+                    if n < buf.len() {
+                        break;
+                    }
+                }
+                let msg = if compiled.is_empty() {
+                    "No handshake could be completed".to_string()
+                } else {
+                    String::from_utf8_lossy(&compiled).replace('\n', " ")
+                };
+                return Ok((msg, Some(stream)));
+            }
+            Ok(Err(e)) => return Err(CodexErr::Io(e)),
+            Err(_) => {
+                tracing::info!("Waiting for API handshake attempt {}", attempts);
+            }
+        }
+    }
+}
+
+pub async fn send_payload(mut stream: TcpStream, payload: &[u8]) -> std::io::Result<Vec<u8>> {
+    stream.write_all(payload).await?;
+    stream.shutdown().await?;
+    let mut resp = Vec::new();
+    stream.read_to_end(&mut resp).await?;
+    Ok(resp)
+}

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod exec_env;
 pub mod config_types;
 pub mod config;
 pub mod protocol;
+pub mod api;
 // Add other module declarations if needed, e.g.:
 // pub mod codex;
 // pub mod another_module;

--- a/codex-rs/core/tests/exec_api_test.rs
+++ b/codex-rs/core/tests/exec_api_test.rs
@@ -11,10 +11,9 @@ async fn test_spawn_command_under_api() {
     let stdio_policy = StdioPolicy::RedirectForShellTool;
     let env = HashMap::new();
 
-    match spawn_command_under_api(command, &sandbox_policy, cwd, stdio_policy, env).await {
-        Ok(child) => {
-            let output = child.wait_with_output().await.expect("Failed to wait for child process");
-            assert!(output.status.success(), "Process did not exit successfully");
+    match spawn_command_under_api(command, &sandbox_policy, cwd, stdio_policy, env, None).await {
+        Ok(output) => {
+            assert!(output.exit_status.success(), "Process did not exit successfully");
             let stdout = String::from_utf8_lossy(&output.stdout);
             assert!(stdout.contains("Hello, World!"), "Unexpected output: {}", stdout);
         }


### PR DESCRIPTION
## Summary
- create `api` module with helpers for accepting API connections and sending payloads
- refactor `spawn_command_under_api` to use new helpers and send command payloads for non-interpreters
- run interpreter and handshake concurrently and prefix handshake to output

## Testing
- `cargo test -p codex-core --test exec_api_test -- --nocapture` *(fails: Process did not exit successfully)*

------
https://chatgpt.com/codex/tasks/task_e_685455b54dc0832a829785167fbb5904