### PR TITLE
Add detailed Windows sandbox scripts

### DIFF
--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -397,7 +397,12 @@ pub async fn spawn_command_under_win64_cmd(
 ) -> std::io::Result<Child> {
     #[cfg(windows)]
     {
-        let batch_script_path = "path_to_batch_script.bat"; // Placeholder for batch script path
+        // Use a helper script to restrict command execution. This wrapper denies
+        // attempts to change directories above the current working directory.
+        let batch_script_path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/scripts/win64_cmd_restricted.bat"
+        );
         let mut cmd = Command::new("cmd.exe");
         cmd.arg("/C").arg(batch_script_path);
         cmd.args(&_command);
@@ -438,7 +443,11 @@ pub async fn spawn_command_under_win64_ps(
 ) -> std::io::Result<Child> {
     #[cfg(windows)]
     {
-        let powershell_script_path = "path_to_powershell_script.ps1"; // Placeholder for PowerShell script path
+        // PowerShell version of the restricted wrapper.
+        let powershell_script_path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/scripts/win64_ps_restricted.ps1"
+        );
         let mut cmd = Command::new("powershell.exe");
         cmd.arg("-File").arg(powershell_script_path);
         cmd.args(&_command);

--- a/codex-rs/scripts/bash_restricted.sh
+++ b/codex-rs/scripts/bash_restricted.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Restricted shell wrapper: disallows `cd ..` to keep execution within current directory
+if [[ " $* " =~ (^|[[:space:]])cd[[:space:]]+\.\.( |$) ]]; then
+  echo "Error: 'cd ..' is not allowed." >&2
+  exit 1
+fi
+"$@"

--- a/codex-rs/scripts/win64_cleanup.bat
+++ b/codex-rs/scripts/win64_cleanup.bat
@@ -1,0 +1,3 @@
+@echo off
+net user SandboxUser /del >nul 2>&1
+rd /s /q "%CD%\sandbox"

--- a/codex-rs/scripts/win64_cleanup.ps1
+++ b/codex-rs/scripts/win64_cleanup.ps1
@@ -1,0 +1,2 @@
+Remove-LocalUser -Name SandboxUserPS -ErrorAction SilentlyContinue
+Remove-Item "$PWD\sandbox" -Recurse -Force -ErrorAction SilentlyContinue

--- a/codex-rs/scripts/win64_cmd_restricted.bat
+++ b/codex-rs/scripts/win64_cmd_restricted.bat
@@ -1,0 +1,38 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+:: Configuration
+set "SANDBOX_USER=SandboxUser"
+set "SANDBOX_PASS=YourStrongP@ssw0rd"
+set "SANDBOX_ROOT=%CD%\sandbox"
+set "DEPTH=3"
+
+:: Create the user if needed
+net user "%SANDBOX_USER%" "%SANDBOX_PASS%" /add /expires:never /passwordchg:no /passwordreq:yes >nul 2>&1
+net localgroup Users "%SANDBOX_USER%" /add >nul 2>&1
+
+:: Prepare sandbox root
+if exist "%SANDBOX_ROOT%" rd /s /q "%SANDBOX_ROOT%"
+md "%SANDBOX_ROOT%"
+
+:: Build nested directories under sandbox root
+set "PREV=%SANDBOX_ROOT%"
+for /L %%i in (1,1,%DEPTH%) do (
+    set "DEST=%SANDBOX_ROOT%\copy_%%i"
+    xcopy "%PREV%" "!DEST!" /E /I /H /C /Y >nul
+    set "PREV=!DEST!"
+)
+
+:: Validate command line
+set "CMDLINE=%*"
+echo %CMDLINE% | findstr /R "\<cd\s*\.\." >nul
+if %errorlevel%==0 (
+    echo Error: 'cd ..' is not allowed.
+    exit /B 1
+)
+
+:: Launch command under restricted user
+echo Launching sandbox as %SANDBOX_USER% in %SANDBOX_ROOT%...
+runas /user:%COMPUTERNAME%\%SANDBOX_USER% "cmd.exe /c cd /d \"%SANDBOX_ROOT%\" && %CMDLINE%"
+
+endlocal

--- a/codex-rs/scripts/win64_ps_restricted.ps1
+++ b/codex-rs/scripts/win64_ps_restricted.ps1
@@ -1,0 +1,36 @@
+param(
+  [string[]]$Command,
+  [int]$Depth = 3,
+  [string]$Username = "SandboxUserPS",
+  [string]$PasswordPlain = "YourStrongP@ssw0rd"
+)
+
+$secPass = ConvertTo-SecureString $PasswordPlain -AsPlainText -Force
+if (-not (Get-LocalUser -Name $Username -ErrorAction SilentlyContinue)) {
+    New-LocalUser -Name $Username -Password $secPass -PasswordNeverExpires -UserMayNotChangePassword
+}
+Add-LocalGroupMember -Group Users -Member $Username -ErrorAction SilentlyContinue
+
+$origPath    = (Get-Location).ProviderPath
+$sandboxRoot = Join-Path $origPath "sandbox"
+if (Test-Path $sandboxRoot) {
+    Remove-Item $sandboxRoot -Recurse -Force
+}
+New-Item -ItemType Directory -Path $sandboxRoot | Out-Null
+
+$prevPath = $sandboxRoot
+for ($i = 1; $i -le $Depth; $i++) {
+    $dest = Join-Path $sandboxRoot "copy_$i"
+    Copy-Item $prevPath $dest -Recurse -Force
+    $prevPath = $dest
+}
+
+$cmdLine = $Command -join ' '
+if ($cmdLine -match '\bcd\s+\.\.') {
+    Write-Error "cd .. is not allowed."
+    exit 1
+}
+
+Write-Host "Launching sandbox as $Username in $sandboxRoot" -ForegroundColor Green
+$cred = New-Object System.Management.Automation.PSCredential("$env:COMPUTERNAME\$Username", $secPass)
+Start-Process -FilePath pwsh.exe -ArgumentList "-NoExit","-Command","Set-Location -LiteralPath '$sandboxRoot'; $cmdLine" -Credential $cred


### PR DESCRIPTION
## Summary
- flesh out Windows CMD and PowerShell restricted wrappers
- add cleanup scripts for removing sandbox users and folders

## Testing
- `cargo check --manifest-path codex-rs/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_6854add1b35c832aac947f2e61efdc8a