### PR TITLE
Ensure sandbox ownership in windows scripts

### DIFF
--- a/codex-rs/scripts/win64_cmd_restricted.bat
+++ b/codex-rs/scripts/win64_cmd_restricted.bat
@@ -15,6 +15,8 @@ net localgroup Users "%SANDBOX_USER%" /add /Y
 if exist "%SANDBOX_ROOT%" rd /s /q "%SANDBOX_ROOT%"
 md "%SANDBOX_ROOT%"
 
+rem Set the sandbox directory owner before adjusting permissions
+icacls "%SANDBOX_ROOT%" /setowner %SANDBOX_USER% /T /C
 icacls "%SANDBOX_ROOT%" /inheritance:r
 icacls "%SANDBOX_ROOT%" /grant:r %SANDBOX_USER%:(OI)(CI)F
 :: Build nested directories under sandbox root

--- a/codex-rs/scripts/win64_ps_restricted.ps1
+++ b/codex-rs/scripts/win64_ps_restricted.ps1
@@ -18,6 +18,11 @@ if (Test-Path $sandboxRoot) {
 }
 New-Item -ItemType Directory -Path $sandboxRoot | Out-Null
 
+# Set the sandbox directory owner before adjusting permissions
+icacls $sandboxRoot /setowner $Username /T /C | Out-Null
+icacls $sandboxRoot /inheritance:r | Out-Null
+icacls $sandboxRoot /grant:r "$Username:(OI)(CI)F" | Out-Null
+
 $prevPath = $sandboxRoot
 for ($i = 1; $i -le $Depth; $i++) {
     $dest = Join-Path $sandboxRoot "copy_$i"


### PR DESCRIPTION
## Summary
- adjust `win64_cmd_restricted.bat` to set sandbox directory owner before setting ACL
- update `win64_ps_restricted.ps1` similarly

## Testing
- `pnpm test` *(fails: ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL)*
- `cargo test` in `codex-rs` *(fails to compile `codex-core` test)*

------
https://chatgpt.com/codex/tasks/task_e_6855a5e9087c832aad1188e492a8a7d5