### PR TITLE
Handle internal shell commands via black box

### DIFF
--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -20,6 +20,7 @@ codex-login = { path = "../login" }
 codex-mcp-client = { path = "../mcp-client" }
 codex-execpolicy = { path = "../execpolicy" }
 translation = { path = "../translation" }
+internal_commands = { path = "../internal_commands" }
 dirs = "6"
 env-flags = "0.1.1"
 eventsource-stream = "0.2.3"


### PR DESCRIPTION
## Summary
- implement `spawn_internal_command_child` for black box
- route internal shell commands through the black box path
- include `internal_commands` crate in core dependencies

## Testing
- `cargo check --manifest-path codex-rs/core/Cargo.toml` *(fails: multiple workspace roots)*

------
https://chatgpt.com/codex/tasks/task_e_6855cef9efe8832a9522884fd16e0993